### PR TITLE
Save Image feature improvements

### DIFF
--- a/oapdisplay_save_image.pro
+++ b/oapdisplay_save_image.pro
@@ -4,8 +4,8 @@ common block1
 
 filters = ['*.jpg;*.jpeg;*.tif;*.tiff;*.png']
 output_file = Dialog_Pickfile(FILTER = filters, PATH=display_info.output_path, GET_PATH=tmp, $
-  TITLE='Choose directory and enter image name and type (ex. ".png")', /WRITE)
-
+  TITLE='Choose directory and enter image name and type (ex. ".png")', /WRITE, /OVERWRITE_PROMPT)
+display_info.output_path = tmp
 
     i.save, output_file
     MSG1 = 'Image Saved'


### PR DESCRIPTION
After you save an image, the file path that you used becomes the new default directory path. Also, there is now an overwrite prompt for when you accidentally, (or purposefully), choose to save an image as a file name that already exists.