### PR TITLE
Auto-reject on/off, increased maximum diameter, and minor bug fixes

### DIFF
--- a/oapdisplay.pro
+++ b/oapdisplay.pro
@@ -7,7 +7,7 @@ PRO OAPdisplay
 
 
   common block1, fileinfo, base_widg, display_info, prbtype, hhmmss, pos, scnt, rec, diam, percentage, nth, hab, i, auto_reject, touching_edge, hole_diam, $
-   habit_selection, timestamp_selection, color_selection, holes_selection, PTE_sel, $ 
+   habit_selection, timestamp_selection, color_selection, holes_selection, PTE_sel, reject_sel, $ 
    time_disp, pos_disp, $
    color_array, color, base_widg2, droplist, $
    dendrite_values,irregular_values, hexagonal_values, spherical_values, graupel_values, aggregate_values, oriented_values, centerout_values, linear_values, tiny_values, zero_values
@@ -102,6 +102,8 @@ zero_values=['white','Do not alter']
     xoff=460,xsize=80,ysize=75, /FRAME, uname='holes_widg', event_funct='OAPdisplay_particle_criteria_event', set_value=0)
   PTE_widg_id=CW_BGROUP(base_widg,'Entire-In', Column=1,/NONEXCLUSIVE,$
     xoff=92,/FRAME,yoff=105,xsize=75,ysize=25, uname='PTE_widg', event_funct='OAPdisplay_particle_criteria_event', set_value=1)
+  reject_widg_id=CW_BGROUP(base_widg,'Auto-Reject', Column=1,/NONEXCLUSIVE,$
+    xoff=290,/FRAME,yoff=105,xsize=85,ysize=25, uname='reject_widg', event_funct='OAPdisplay_particle_criteria_event', set_value=1)
 
   
   colors_widg_id=CW_BGROUP(base_widg,' Colors', Column=1, /NONEXCLUSIVE, $

--- a/oapdisplay.pro
+++ b/oapdisplay.pro
@@ -17,8 +17,8 @@ PRO OAPdisplay
 
   display_info = {fname_base:'No File Selected', fname_proc:'No File Selected', path:'/kingair_data/snowie17/2DS/', output_path:'/home', $
     nrec: 'No Records to Show', range_time:'hhmmss -- hhmmss', $
-    image_percent:'% of accepted particles shown: --%', stt_time:'hhmmss', stp_time:'hhmmss', min_size:'0', max_size:'2000', nth_part:'1', $
-    img_stt:'Image Start: hhmmss', img_stp:'Image Stop: hhmmss', img_minD:'Image MinD: 0',  img_maxD:'Image MaxD: 2000', $ 
+    image_percent:'% of accepted particles shown: --%', stt_time:'hhmmss', stp_time:'hhmmss', min_size:'0', max_size:'5000', nth_part:'1', $
+    img_stt:'Image Start: hhmmss', img_stp:'Image Stop: hhmmss', img_minD:'Image MinD: 0',  img_maxD:'Image MaxD: 5000', $ 
     first:-999L, last:-999L, buf_full:0L}
 
   hhmmss=0L & pos=0L & scnt=0L & rec=0L & diam=0L & prbtype =''

--- a/oapdisplay_event.pro
+++ b/oapdisplay_event.pro
@@ -45,7 +45,7 @@ PRO OAPdisplay_event,ev
   maxD_widg_id =  WIDGET_INFO(ev.top,find_by_uname='maxD_widg')
   WIDGET_CONTROL, get_value=tmp, maxD_widg_id
   IF (LONG(tmp) LT 1) THEN tmp = STRTRIM( STRING(1),2)
-  IF (LONG(tmp) GT 2000) THEN tmp = STRTRIM( STRING(2000),2)
+  IF (LONG(tmp) GT 5000) THEN tmp = STRTRIM( STRING(2000),2)
   WIDGET_CONTROL, set_value=tmp, maxD_widg_id
   maxD = LONG((tmp)[0]) / 1000. ; change maxD to mm
   IF maxD LE minD Then Begin

--- a/oapdisplay_event.pro
+++ b/oapdisplay_event.pro
@@ -80,6 +80,10 @@ PRO OAPdisplay_event,ev
   PTE_widg_id = WIDGET_INFO(ev.top,find_by_uname='PTE_widg')
   WIDGET_CONTROL, get_value=PTE_sel, PTE_widg_id
   
+  ;checks to see if rejected particles are selected to display
+  reject_widg_id = WIDGET_INFO(ev.top,find_by_uname='reject_widg')
+  WIDGET_CONTROL, get_value=reject_sel, reject_widg_id
+  
   ;checks to see if habit colors are selected to display
   colors_widg_id = WIDGET_INFO(ev.top,find_by_uname='colors_widg')
   WIDGET_CONTROL, get_value=color_selection, colors_widg_id

--- a/oapdisplay_get_buffers.pro
+++ b/oapdisplay_get_buffers.pro
@@ -247,7 +247,7 @@ For x=0, N_ELEMENTS(where_buf2)-1 DO BEGIN
   For z= y, v[0] DO BEGIN
     color_array[z,1]= assigned_color[[where2_buf2[x]],1]
   Endfor
-  y=v[0] + 1
+  y=v[0]
 ENDFOR
 
 x=0

--- a/oapdisplay_get_buffers.pro
+++ b/oapdisplay_get_buffers.pro
@@ -7,8 +7,11 @@ PRO OAPdisplay_get_buffers, tmp, minD, maxD, inds, npart, hab_sel, first, last, 
   x=0
   color_array= make_array(1700,4, VALUE=255)
   
-  bad_PTE=0                                          ; Checks to see if timestamps have been selected to display
+  bad_PTE=0                                          ; Checks to see if particles touching the edge have been selected to display
   IF (PTE_sel[0]) THEN bad_PTE=1
+  
+  bad_reject=0                                          ; Checks to see if rejected particles have been selected to display
+  IF (reject_sel[0]) THEN bad_reject=1
   
   ;Initialize pertinent variables
   display_info.buf_full = 0  ;display buffers are not all full
@@ -53,7 +56,9 @@ PRO OAPdisplay_get_buffers, tmp, minD, maxD, inds, npart, hab_sel, first, last, 
      IF (bad_PTE) THEN BEGIN
       IF (touching_edge[i] GT 1) THEN CONTINUE  ;image cannot be touching the edge
      ENDIF
-    IF (auto_reject[i] GT 50) THEN CONTINUE   ;auto reject of 48 is accepted, all others are rejected
+     IF (bad_reject) THEN BEGIN
+      IF (auto_reject[i] GT 50) THEN CONTINUE   ;auto reject of 48 is accepted, all others are rejected
+     ENDIF
     tot_parts=temporary(tot_parts)+1
     IF (diam[i] LT minD) THEN CONTINUE        ;particle is too small, skip it
     IF (diam[i] GT maxD) THEN CONTINUE        ;particle is too large, skip it
@@ -141,7 +146,9 @@ PRO OAPdisplay_get_buffers, tmp, minD, maxD, inds, npart, hab_sel, first, last, 
        IF (bad_PTE) THEN BEGIN
         IF (touching_edge[i] GT 1) THEN CONTINUE  ;image cannot be touching the edge
        ENDIF
-      IF (auto_reject[i] GT 50) THEN CONTINUE  ;auto reject of 48 is accepted, all others are rejected
+       IF (bad_reject) THEN BEGIN
+        IF (auto_reject[i] GT 50) THEN CONTINUE   ;auto reject of 48 is accepted, all others are rejected
+       ENDIF
       IF (diam[i] LT minD) THEN CONTINUE
       IF (diam[i] GT maxD) THEN CONTINUE
       IF (i mod nth NE 0) THEN CONTINUE
@@ -212,8 +219,8 @@ PRO OAPdisplay_get_buffers, tmp, minD, maxD, inds, npart, hab_sel, first, last, 
     ENDFOR
   ENDFOR
   
- where=where(position[*,0] NE -999)
- where2=where(assigned_color[*,0] NE 255)
+ where_buf1=where(position[*,0] NE -999)
+ where2_buf1=where(assigned_color[*,0] NE 255)
 
  where_buf2=where(position[*,1] NE -999)
  where2_buf2=where(assigned_color[*,1] NE 255)
@@ -231,10 +238,10 @@ v=lonarr(1)
  x=0
  y=0
  z=0
- For x=0, N_ELEMENTS(where)-1 DO BEGIN
+ For x=0, N_ELEMENTS(where_buf1)-1 DO BEGIN
   v[0]=LONG(position[x,0]) 
   For z= y, v[0] DO BEGIN
-  color_array[z,0]= assigned_color[[where2[x]],0]
+  color_array[z,0]= assigned_color[[where2_buf1[x]],0]
   Endfor
  y=v[0]
  ENDFOR

--- a/oapdisplay_particle_criteria_event.pro
+++ b/oapdisplay_particle_criteria_event.pro
@@ -16,7 +16,7 @@ FUNCTION OAPdisplay_particle_criteria_event,ev
     (ev.ID EQ (WIDGET_INFO(ev.top,find_by_uname='maxD_widg')) ) : BEGIN
       WIDGET_CONTROL, get_value=tmp, ev.id
       IF (LONG(tmp) LT 1) THEN tmp = STRTRIM( STRING(1),2)
-      IF (LONG(tmp) GT 2000) THEN tmp = STRTRIM( STRING(2000),2)
+      IF (LONG(tmp) GT 5000) THEN tmp = STRTRIM( STRING(5000),2)
       WIDGET_CONTROL, set_value=tmp, ev.id
     END
     (ev.ID EQ (WIDGET_INFO(ev.top,find_by_uname='nth_part_widg')) ) : BEGIN

--- a/oapdisplay_particle_criteria_event.pro
+++ b/oapdisplay_particle_criteria_event.pro
@@ -33,6 +33,10 @@ FUNCTION OAPdisplay_particle_criteria_event,ev
       WIDGET_CONTROL, get_value=tmp, ev.id
       PTE_selection=tmp
     END
+    (ev.ID EQ (WIDGET_INFO(ev.top,find_by_uname='reject_widg')) ) : BEGIN
+      WIDGET_CONTROL, get_value=tmp, ev.id
+      reject_selection=tmp
+    END
     (ev.ID EQ (WIDGET_INFO(ev.top,find_by_uname='colors_widg')) ) : BEGIN
       WIDGET_CONTROL, get_value=tmp, ev.id
       color_selection=tmp

--- a/oapdisplay_showbuffers.pro
+++ b/oapdisplay_showbuffers.pro
@@ -27,7 +27,7 @@ common block1
         end_buf=1
         FOR i=1700-1,0,-1 DO BEGIN
           CASE end_buf of
-            0: IF(TOTAL(data_record[m,*,i]) EQ 128 ) THEN data_record[m,*,i]=0
+            0: IF(TOTAL(data_record[m,*,i]) EQ 128 ) THEN data_record[m,*,i]=1
             1: IF(TOTAL(data_record[m,*,i]) NE 128 ) THEN end_buf=0
           ENDCASE
         ENDFOR
@@ -64,7 +64,7 @@ common block1
         end_buf=1
         FOR i=850-1,0,-1 DO BEGIN
           CASE end_buf of
-            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=0
+            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=1
             1: IF(TOTAL(data_record[m,*,i]) NE 64 ) THEN end_buf=0
           ENDCASE
         ENDFOR
@@ -97,7 +97,7 @@ common block1
         end_buf=1
         FOR i=850-1,0,-1 DO BEGIN
           CASE end_buf of
-            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=0
+            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=1
             1: IF(TOTAL(data_record[m,*,i]) NE 64 ) THEN end_buf=0
           ENDCASE
         ENDFOR

--- a/oapdisplay_showbuffers.pro
+++ b/oapdisplay_showbuffers.pro
@@ -27,7 +27,7 @@ common block1
         end_buf=1
         FOR i=1700-1,0,-1 DO BEGIN
           CASE end_buf of
-            0: IF(TOTAL(data_record[m,*,i]) EQ 128 ) THEN data_record[m,*,i]=1
+            0: IF(TOTAL(data_record[m,*,i]) EQ 128 ) THEN data_record[m,*,i]=0
             1: IF(TOTAL(data_record[m,*,i]) NE 128 ) THEN end_buf=0
           ENDCASE
         ENDFOR
@@ -64,7 +64,7 @@ common block1
         end_buf=1
         FOR i=850-1,0,-1 DO BEGIN
           CASE end_buf of
-            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=1
+            0: IF(TOTAL(data_record[m,*,i]) EQ 64 ) THEN data_record[m,*,i]=0
             1: IF(TOTAL(data_record[m,*,i]) NE 64 ) THEN end_buf=0
           ENDCASE
         ENDFOR


### PR DESCRIPTION
I found a tiny mistake in my original code that caused the first slice of each particle in the second buffer to be incorrectly colored according to the particle before it. I also created an Auto-reject on/off button that allows the user to display rejected particles if they want to. I also increased the maximum diameter from 2000 to 5000 microns, which should be more than enough to show all possible particle images. Finally, I believe that the issue where fully occulted slices were not being shown has being fixed.